### PR TITLE
Removed sharedconfig from aws sdk setup

### DIFF
--- a/alpha.go
+++ b/alpha.go
@@ -91,8 +91,8 @@ func (client *Alpha) Gql(uri string, query string, variables map[string]interfac
 	return &body.Data, nil
 }
 
-func BuildAlphaClient(env string, account string, user string, rules map[string]bool) (*Alpha, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile(env))
+func BuildAlphaClient(account string, user string, rules map[string]bool) (*Alpha, error) {
+	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client, err := alpha.BuildAlphaClient("lifeomic-dev", "lifeomic", args.User, map[string]bool{})
+	client, err := alpha.BuildAlphaClient("lifeomic", args.User, map[string]bool{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
We don't actually need this now that the okta stuff is working correctly.