### PR TITLE
doc: Cleaned up README to make it clear that it currently only supports internal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This is a simple library used to wrap common behavior when interacting with lifeomic services.
+The goal is support more of a public API through the graphql proxy, but initially it only
+supports direct lambda invocations.
+
+
 See `cmds/main.go` for example usage.
 
 To run example do something like this:
@@ -5,5 +10,3 @@ To run example do something like this:
 ```
 go run cmd/main.go --query=query.graphql --variables=var.json --uri=marketplace-service:deployed --user=marketplace-tf
 ```
-
-Note: Must be authenticated in the dev environment (`lifeomic-aws login`)


### PR DESCRIPTION
I was asked to remove the reference to our internal tooling.