### PR TITLE
feat: Added sub clients for different services

### DIFF
--- a/client/appStore.go
+++ b/client/appStore.go
@@ -44,9 +44,7 @@ const GRAPHQL_URL = "/graphql"
 
 type AppStoreClient struct {
 	graphqlUrl string
-	client     interface {
-		Gql(string, string, map[string]interface{}) (*map[string]interface{}, error)
-	}
+	client     graphqlClient
 }
 
 type app struct {

--- a/client/appStore.go
+++ b/client/appStore.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"errors"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const GET_APP_STORE_LISTING = `
+  query GetAppStoreListing($id: ID!) {
+    app(id: $id) {
+      name
+      description
+      authorDisplay
+      image
+      ... on AppStoreWebApplication {
+        url
+      }
+    }
+  }
+`
+
+const DELETE_APP_STORE_LISTING = `
+  mutation DeleteAppStoreListing($id: ID!) {
+	deleteApp(id: $id)
+  }
+`
+
+const CREATE_APP_STORE_LISTING = `
+  mutation CreateAppStoreListing($input: CreateWebAppInput!) {
+    createWebApp(input: $input) {
+      id
+    }
+  }
+`
+
+const EDIT_APP_STORE_LISTING = `
+  mutation EditAppStoreListing($id: ID!, $edits: EditWebAppInput!) {
+    editWebApp(id: $id, edits: $edits) 
+  }
+`
+
+const GRAPHQL_URL = "/graphql"
+
+type AppStoreClient struct {
+	graphqlUrl string
+	client     interface {
+		Gql(string, string, map[string]interface{}) (*map[string]interface{}, error)
+	}
+}
+
+type app struct {
+	Name          string
+	Description   string
+	AuthorDisplay string
+	Image         string
+	Url           string
+}
+
+func (self *AppStoreClient) Gql(query string, variables map[string]interface{}) (*map[string]interface{}, error) {
+	return self.client.Gql(self.graphqlUrl, query, variables)
+}
+
+func (self *AppStoreClient) GetAppStoreListing(id string) (*app, error) {
+	res, err := self.Gql(GET_APP_STORE_LISTING, map[string]interface{}{"id": id})
+	if err != nil {
+		return nil, err
+	}
+
+	var data struct {
+		App app
+	}
+	err = mapstructure.Decode(res, &data)
+	if err != nil {
+		return nil, err
+	}
+	return &data.App, nil
+}
+
+type appStoreCreate struct {
+	Name          string
+	AuthorDisplay string
+	Url           string
+	Description   string
+	Image         string
+}
+
+func (self *AppStoreClient) CreateAppStoreListing(params appStoreCreate) (*string, error) {
+	res, err := self.Gql(CREATE_APP_STORE_LISTING, map[string]interface{}{"input": map[string]string{
+		"name":          params.Name,
+		"authorDisplay": params.AuthorDisplay,
+		"url":           params.Url,
+		"description":   params.Description,
+		"image":         params.Image,
+		"product":       "LX",
+	}})
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		CreateWebApp struct {
+			Id string
+		}
+	}
+	err = mapstructure.Decode(res, &data)
+	if err != nil {
+		return nil, err
+	}
+	return &data.CreateWebApp.Id, nil
+}
+
+func (self *AppStoreClient) EditAppStoreListing(id string, params appStoreCreate) error {
+	res, err := self.Gql(EDIT_APP_STORE_LISTING, map[string]interface{}{
+		"id": id,
+		"edits": map[string]string{
+			"name":          params.Name,
+			"authorDisplay": params.AuthorDisplay,
+			"url":           params.Url,
+			"description":   params.Description,
+			"image":         params.Image,
+		}})
+	if err != nil {
+		return err
+	}
+
+	var data struct {
+		EditWebApp bool
+	}
+	err = mapstructure.Decode(res, &data)
+	if err != nil {
+		return err
+	}
+	if !data.EditWebApp {
+		return errors.New("The app you're trying to edit does not exist")
+	}
+	return nil
+}
+
+func (self *AppStoreClient) DeleteAppStoreListing(id string) error {
+	res, err := self.Gql(DELETE_APP_STORE_LISTING, map[string]interface{}{
+		"id": id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var data struct {
+		DeleteApp bool
+	}
+	err = mapstructure.Decode(res, &data)
+	if err != nil {
+		return err
+	}
+	if !data.DeleteApp {
+		return errors.New("The app you're trying to delete does not exist")
+	}
+	return nil
+}

--- a/client/appStore_test.go
+++ b/client/appStore_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestGetAppStoreListing(t *testing.T) {
+	mockResponse := map[string]interface{}{
+		"app": map[string]interface{}{
+			"name":          "test title",
+			"description":   "test description",
+			"authorDisplay": "Cool Author",
+			"url":           "some_url",
+			"image":         "some_image_url",
+		},
+	}
+	mockClient := MockClient{
+		response: &mockResponse,
+	}
+	client := AppStoreClient{
+		client:     &mockClient,
+		graphqlUrl: "marketplace-service:deployed/v1/marketplace/authenticated/graphql",
+	}
+	response, err := client.GetAppStoreListing("some_module_id")
+	if err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+
+	if !mockClient.hasBeenCalled {
+		t.Fatal("Mock Client never called")
+	}
+
+	if response == nil {
+		t.Fatal("Response should not be nil")
+	}
+
+	if response.Description != "test description" {
+		t.Fatal("Did not get back currect response", response)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -34,10 +34,12 @@ type responseBody struct {
 	} `json:"errors"`
 }
 
+type Invoker interface {
+	Invoke(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+}
+
 type LambdaClient struct {
-	invoker interface {
-		Invoke(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
-	}
+	invoker Invoker
 	account string
 	user    string
 	rules   map[string]bool

--- a/client/client.go
+++ b/client/client.go
@@ -34,18 +34,16 @@ type responseBody struct {
 	} `json:"errors"`
 }
 
-type Invoker interface {
-	Invoke(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
-}
-
-type Client struct {
-	invoker Invoker
+type LambdaClient struct {
+	invoker interface {
+		Invoke(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+	}
 	account string
 	user    string
 	rules   map[string]bool
 }
 
-func (c *Client) buildGqlQuery(path string, query string, variables map[string]interface{}) []byte {
+func (c *LambdaClient) buildGqlQuery(path string, query string, variables map[string]interface{}) []byte {
 	type Body struct {
 		Query     string                 `json:"query"`
 		Variables map[string]interface{} `json:"variables"`
@@ -78,12 +76,11 @@ func parseUri(uri string) (*string, *string, error) {
 	return &functionName, &path, nil
 }
 
-func (c *Client) Gql(uri string, query string, variables map[string]interface{}) (*map[string]interface{}, error) {
+func (c *LambdaClient) Gql(uri string, query string, variables map[string]interface{}) (*map[string]interface{}, error) {
 	functionName, path, err := parseUri(uri)
 	if err != nil {
 		return nil, err
 	}
-	// MP_ARN := "marketplace-service:deployed"
 	resp, err := c.invoker.Invoke(context.Background(), &lambda.InvokeInput{
 		FunctionName: functionName,
 		Payload:      c.buildGqlQuery(*path, query, variables),
@@ -109,11 +106,25 @@ func (c *Client) Gql(uri string, query string, variables map[string]interface{})
 	return &body.Data, nil
 }
 
-func BuildClient(account string, user string, rules map[string]bool) (*Client, error) {
+func (c *LambdaClient) AppStore() AppStoreClient {
+	return AppStoreClient{
+		client:     c,
+		graphqlUrl: "app-store-service:deployed/graphql",
+	}
+}
+
+func (c *LambdaClient) Marketplace() MarketplaceClient {
+	return MarketplaceClient{
+		client:     c,
+		graphqlUrl: "marketplace-service:deployed/v1/marketplace/authenticated/graphql",
+	}
+}
+
+func BuildClient(account string, user string, rules map[string]bool) (*LambdaClient, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	client := Client{invoker: lambda.NewFromConfig(cfg), user: user, rules: rules, account: account}
+	client := LambdaClient{invoker: lambda.NewFromConfig(cfg), user: user, rules: rules, account: account}
 	return &client, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,7 +17,7 @@ mutation MockMutation($var: String!) {
 `
 
 func TestBuildGqlQuery(t *testing.T) {
-	client := Client{
+	client := LambdaClient{
 		rules: map[string]bool{
 			"testRule": true,
 		},
@@ -76,7 +76,7 @@ func TestGql(t *testing.T) {
 			Payload: []byte("{ \"body\": \"{ \\\"data\\\": { \\\"result\\\": true }}\"}"),
 		},
 	}
-	client := Client{
+	client := LambdaClient{
 		invoker: &mock,
 	}
 

--- a/client/graphqlClient.go
+++ b/client/graphqlClient.go
@@ -1,0 +1,5 @@
+package client
+
+type graphqlClient interface {
+	Gql(string, string, map[string]interface{}) (*map[string]interface{}, error)
+}

--- a/client/marketplace.go
+++ b/client/marketplace.go
@@ -13,9 +13,7 @@ import (
 
 type MarketplaceClient struct {
 	graphqlUrl string
-	client     interface {
-		Gql(string, string, map[string]interface{}) (*map[string]interface{}, error)
-	}
+	client     graphqlClient
 }
 
 func (self *MarketplaceClient) Gql(query string, variables map[string]interface{}) (*map[string]interface{}, error) {

--- a/client/marketplace.go
+++ b/client/marketplace.go
@@ -1,0 +1,304 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type MarketplaceClient struct {
+	graphqlUrl string
+	client     interface {
+		Gql(string, string, map[string]interface{}) (*map[string]interface{}, error)
+	}
+}
+
+func (self *MarketplaceClient) Gql(query string, variables map[string]interface{}) (*map[string]interface{}, error) {
+	return self.client.Gql(self.graphqlUrl, query, variables)
+}
+
+const GET_PUBLISHED_APP_TILE_MODULE = `
+  query GetPublishedModule($id: ID!, $version: String) {
+    myModule(moduleId: $id, version: $version) {
+      title
+      description
+	  version
+	  source {
+		... on AppTile {
+		  id
+		}
+	  }
+	  iconV2 {
+		url
+		fileName
+		fileExtension
+	  }
+    }
+  }
+`
+
+const CREATE_DRAFT_MODULE = `
+ mutation CreateDraftModule($input: CreateDraftModuleInput!) {
+   createDraftModule(input: $input) {
+     id
+   }
+ }
+`
+
+const SET_APP_TILE = `
+  mutation SetAppTile($input: SetPublicAppTileDraftModuleSourceInput!) {
+	setPublicAppTileDraftModuleSource(input: $input) {
+	  moduleId
+	}
+  }
+`
+
+const PUBLISH_MODULE = `
+  mutation PublishModule($input: PublishDraftModuleInputV2!) {
+	publishDraftModuleV2(input: $input) {
+	  id
+	  version {
+		version
+	  }
+	}
+  }
+`
+
+const START_IMAGE_UPLOAD = `
+  mutation StartImageUpload($input: StartUploadInput!) {
+	startUpload(input: $input) {
+	  id
+	  url
+	  fields
+	}
+  }
+`
+
+const FINALIZE_IMAGE_UPLOAD = `
+  mutation FinalizeImageUpload($input: FinalizeUploadInput!) {
+	finalizeUpload(input: $input) {
+	  moduleId
+	}
+  }
+`
+
+type appTileModule struct {
+	Title       string
+	Description string
+	Version     string
+	Source      struct {
+		Id string
+	}
+	IconV2 *struct {
+		Url           string
+		FileName      string
+		FileExtension string
+	}
+}
+
+func (self *MarketplaceClient) GetAppTileModule(id string) (*appTileModule, error) {
+	res, err := self.Gql(GET_PUBLISHED_APP_TILE_MODULE, map[string]interface{}{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		MyModule *appTileModule
+	}
+	err = mapstructure.Decode(res, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data.MyModule, nil
+}
+
+type appTileCreate struct {
+	Name           string
+	Description    string
+	Image          string
+	AppTileId      string
+	Version        string
+	ParentModuleId *string
+}
+
+func postImageToUrl(url string, image string, file_name string, fields map[string]string) error {
+	file, err := os.Open(image)
+	if err != nil {
+		return err
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	for key, val := range fields {
+		err = writer.WriteField(key, val)
+		if err != nil {
+			return err
+		}
+	}
+	part, err := writer.CreateFormFile("file", file_name)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	responseBody := &bytes.Buffer{}
+	responseBody.ReadFrom(resp.Body)
+	resp.Body.Close()
+	return nil
+}
+
+func (self *MarketplaceClient) AttachImageToDraftModule(moduleId string, image string) error {
+	fileName := path.Base(image)
+	startResponse, err := self.Gql(START_IMAGE_UPLOAD, map[string]interface{}{
+		"input": map[string]interface{}{
+			"fileName": fileName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	var startData struct {
+		StartUpload struct {
+			Fields map[string]string
+			Url    string
+			Id     string
+		}
+	}
+	err = mapstructure.Decode(startResponse, &startData)
+	if err != nil {
+		return err
+	}
+
+	err = postImageToUrl(startData.StartUpload.Url, image, fileName, startData.StartUpload.Fields)
+	if err != nil {
+		return err
+	}
+
+	finalizeResponse, err := self.Gql(FINALIZE_IMAGE_UPLOAD, map[string]interface{}{
+		"input": map[string]string{
+			"id":       startData.StartUpload.Id,
+			"moduleId": moduleId,
+			"type":     "ICON",
+		},
+	})
+
+	if err != nil {
+		return nil
+	}
+
+	var finalizeData struct {
+		FinalizeUpload struct {
+			ModuleId string
+		}
+	}
+
+	err = mapstructure.Decode(finalizeResponse, &finalizeData)
+	return err
+}
+
+func (self *MarketplaceClient) CreateAppTileDraftModule(params appTileCreate) (*string, error) {
+	res, err := self.Gql(CREATE_DRAFT_MODULE, map[string]interface{}{"input": map[string]interface{}{
+		"title":       params.Name,
+		"description": params.Description,
+		// "iconV2":         params.Image, // Use upload
+		"parentModuleId": params.ParentModuleId,
+		"category":       "APP_TILE",
+	}})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var createDraftData struct {
+		CreateDraftModule struct {
+			Id string
+		}
+	}
+
+	err = mapstructure.Decode(res, &createDraftData)
+	if err != nil {
+		return nil, err
+	}
+
+	moduleId := createDraftData.CreateDraftModule.Id
+
+	res, err = self.Gql(SET_APP_TILE, map[string]interface{}{"input": map[string]interface{}{
+		"moduleId": moduleId,
+		"sourceInfo": map[string]string{
+			"id": params.AppTileId,
+		},
+	}})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var setAppTileData struct {
+		SetPublicAppTileDraftModuleSource struct {
+			ModuleId string
+		}
+	}
+	err = mapstructure.Decode(res, &setAppTileData)
+	if err != nil {
+		return nil, err
+	}
+
+	err = self.AttachImageToDraftModule(moduleId, params.Image)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &moduleId, nil
+}
+
+func (self *MarketplaceClient) PublishNewAppTileModule(params appTileCreate) (*string, error) {
+	draftModuleId, err := self.CreateAppTileDraftModule(params)
+	if err != nil {
+		return nil, err
+	}
+	publishRes, err := self.Gql(PUBLISH_MODULE, map[string]interface{}{"input": map[string]interface{}{
+		"moduleId": draftModuleId,
+		"version": map[string]string{
+			"version": params.Version,
+		},
+	}})
+	if err != nil {
+		return nil, err
+	}
+	var publishModuleData struct {
+		PublishDraftModuleV2 struct {
+			Id      string
+			Version struct {
+				Version string
+			}
+		}
+	}
+	err = mapstructure.Decode(publishRes, &publishModuleData)
+	if err != nil {
+		return nil, err
+	}
+	return &publishModuleData.PublishDraftModuleV2.Id, nil
+}

--- a/client/marketplace_test.go
+++ b/client/marketplace_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestGetAppTileModule(t *testing.T) {
+	mockResponse := map[string]interface{}{
+		"myModule": map[string]interface{}{
+			"title":       "test title",
+			"description": "test description",
+			"version":     "1.0.0",
+			"source": map[string]string{
+				"id": "some_id",
+			},
+			"iconV2": map[string]string{
+				"url":           "some_url",
+				"fileName":      "fancy_file",
+				"fileExtension": "png",
+			},
+		},
+	}
+	mockClient := MockClient{
+		response: &mockResponse,
+	}
+	client := MarketplaceClient{
+		client:     &mockClient,
+		graphqlUrl: "marketplace-service:deployed/v1/marketplace/authenticated/graphql",
+	}
+	response, err := client.GetAppTileModule("some_module_id")
+	if err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+
+	if !mockClient.hasBeenCalled {
+		t.Fatal("Mock Client never called")
+	}
+
+	if response == nil {
+		t.Fatal("Response should not be nil")
+	}
+
+	if response.Description != "test description" {
+		t.Fatal("Did not get back currect response", response)
+	}
+}

--- a/client/test_utils.go
+++ b/client/test_utils.go
@@ -1,0 +1,12 @@
+package client
+
+type MockClient struct {
+	hasBeenCalled bool
+	response      *map[string]interface{}
+	error         error
+}
+
+func (m *MockClient) Gql(url string, operation string, variables map[string]interface{}) (*map[string]interface{}, error) {
+	m.hasBeenCalled = true
+	return m.response, m.error
+}


### PR DESCRIPTION
There's a couple reasons for this:
1. There's no strong reason why a consumer of this client should have to write raw gql
2. Opportunity for abstracting away the lambdas to make public api easier in the future
3. This project has better testing setup than the providers (testing providers is a little tricky)
4. Paves the way to make terraform-provider-phc be able to use one root client for multiple services cleanly